### PR TITLE
Fix receive view layout 

### DIFF
--- a/HodlWallet/UI/Views/ReceiveView.xaml
+++ b/HodlWallet/UI/Views/ReceiveView.xaml
@@ -36,7 +36,7 @@
             </ContentView>
 
             <ContentView FlexLayout.Grow="2" 
-                         HeightRequest="30" >
+                         HeightRequest="30">
                 <Label FontFamily="{DynamicResource Mono-Regular}"
                        FontSize="Small"
                        HorizontalTextAlignment="Center"
@@ -66,7 +66,7 @@
                         <svg:Icon HeightRequest="16"
                                   WidthRequest="16"
                                   HorizontalOptions="End"
-                                  ResourceId="HodlWallet.UI.Assets.close.svg" >
+                                  ResourceId="HodlWallet.UI.Assets.close.svg">
                             <svg:Icon.GestureRecognizers>
                                 <TapGestureRecognizer Command="{Binding CloseCommand}" />
                             </svg:Icon.GestureRecognizers>
@@ -82,8 +82,6 @@
                            Text="{Binding Amount}"
                            TextColor="{DynamicResource FgSuccess}"
                            VerticalOptions="Center" />
-
-
                 </StackLayout>
 
                 <Button BackgroundColor="{DynamicResource Bg2}"


### PR DESCRIPTION
### Summary

The changes on this branch improve some missing details on ReceiveView.

First, the little change on the size of the `QR code` that used to appear after pressing the `Add Amount` button was eliminated.

Next, the size of the `Share` button is the same as the `Send` Button of the `SendView`. And the size of `Request An Amount` button is the same as `Get An Address` button of `HomeView`. It can be seen in the first picture.


### Other Information

As can be seen in the second picture, the size of the amount form is the same of the `Share` button.

The amount entry looks different to the Send's entry, this is because the Receive's entry has a placeholder equal to cero and the Send's entry has the value equal to cero.

It is possible that the correct way to write "Request An Amount" would be with lowercase in the second word, It would be "Request an Amount", this is what Microsoft Word recommends.


![image](https://user-images.githubusercontent.com/77517179/146515056-b356efc1-f9b8-442f-87d9-f5ce767ca51f.png)

![image](https://user-images.githubusercontent.com/77517179/146514289-7c26ec18-2839-496b-bcfe-ec029000ba00.png)

![image](https://user-images.githubusercontent.com/77517179/146515394-5c462da0-ed37-4906-a7d6-df71637bfe86.png)

![image](https://user-images.githubusercontent.com/77517179/146515826-59b7f6ab-1e95-4120-8eac-7993987e5b20.png)
