### PR TITLE
60 settings color bar

### DIFF
--- a/HodlWallet/Core/ViewModels/PinPadViewModel.cs
+++ b/HodlWallet/Core/ViewModels/PinPadViewModel.cs
@@ -37,6 +37,7 @@ namespace HodlWallet.Core.ViewModels
         public string PinPadTitle { get; } = LocaleResources.Pin_enter;
         public string PinPadHeader { get; } = LocaleResources.Pin_header;
         public string PinPadWarning { get; } = LocaleResources.Pin_warning;
+        public string NextView { get; set; };
 
         public ICommand SuccessCommand { get; }
 

--- a/HodlWallet/Core/ViewModels/PinPadViewModel.cs
+++ b/HodlWallet/Core/ViewModels/PinPadViewModel.cs
@@ -37,7 +37,7 @@ namespace HodlWallet.Core.ViewModels
         public string PinPadTitle { get; } = LocaleResources.Pin_enter;
         public string PinPadHeader { get; } = LocaleResources.Pin_header;
         public string PinPadWarning { get; } = LocaleResources.Pin_warning;
-        public string NextView { get; set; };
+        public string NextView { get; set; }
 
         public ICommand SuccessCommand { get; }
 

--- a/HodlWallet/UI/Locale/LocaleResources.Designer.cs
+++ b/HodlWallet/UI/Locale/LocaleResources.Designer.cs
@@ -1216,6 +1216,15 @@ namespace HodlWallet.UI.Locale {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Close.
+        /// </summary>
+        internal static string PinPad_close {
+            get {
+                return ResourceManager.GetString("PinPad.close", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Create A New Pin.
         /// </summary>
         internal static string PinPad_Title {

--- a/HodlWallet/UI/Locale/LocaleResources.Designer.cs
+++ b/HodlWallet/UI/Locale/LocaleResources.Designer.cs
@@ -19,7 +19,7 @@ namespace HodlWallet.UI.Locale {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class LocaleResources {

--- a/HodlWallet/UI/Locale/LocaleResources.resx
+++ b/HodlWallet/UI/Locale/LocaleResources.resx
@@ -580,6 +580,10 @@
     <value>Create A New Pin</value>
     <comment>Pin Pad Title</comment>
   </data>
+  <data name="PinPad.close" xml:space="preserve">
+    <value>Close</value>
+    <comment>label for close button of PinPadView</comment>
+  </data>
   <data name="Recovery.Close" xml:space="preserve">
     <value>Close</value>
     <comment>label for recovery toolbar Close button</comment>

--- a/HodlWallet/UI/Locale/LocaleResources.resx
+++ b/HodlWallet/UI/Locale/LocaleResources.resx
@@ -843,6 +843,10 @@ All you have to do is safety store the wallets backup recovery key and you'll al
     <value>Security</value>
     <comment>label for SecuritySettingsView title</comment>
   </data>
+  <data name="Security.close" xml:space="preserve">
+    <value>Close</value>
+    <comment>label for close button of SecuritySettingsView</comment>
+  </data>
   <data name="PinSettings.pinSpendingLimits" xml:space="preserve">
     <value>Pin Spending Limits</value>
     <comment>label for Pin Spending Limits button of PinSettingsView</comment>

--- a/HodlWallet/UI/Views/BiometricLoginView.xaml.cs
+++ b/HodlWallet/UI/Views/BiometricLoginView.xaml.cs
@@ -92,11 +92,11 @@ namespace HodlWallet.UI.Views
             MessagingCenter.Unsubscribe<LoginViewModel, int>(this, "UpdatePin");
         }
 
-        void UpdatePin(BiometricLoginViewModel _)
+        async void UpdatePin(BiometricLoginViewModel _)
         {
             Debug.WriteLine($"[SubscribeToMessage][UpdatePin]");
 
-            Navigation.PushAsync(new PinPadView(new PinPadChangeView()));
+            await Navigation.PushAsync(new PinPadView("PinPadChangeView"));
             UnsubscribeToMessages();
             return;
         }
@@ -156,13 +156,21 @@ namespace HodlWallet.UI.Views
         {
             UnsubscribeToMessages();
             var view = new LoginView(ViewModel.Action);
-            var nav = new NavigationPage(view);
-            await Navigation.PushModalAsync(nav);
+
+            if (ViewModel.Action == "update")
+            {
+                await Navigation.PushAsync(view);
+            }
+            else
+            {
+                var nav = new NavigationPage(view);
+                await Navigation.PushModalAsync(nav);
+            }
         }
 
-        async void CloseToolbarItem_Clicked(object sender, EventArgs e)
+        void CloseToolbarItem_Clicked(object sender, EventArgs e)
         {
-            await Shell.Current.GoToAsync("../../pinSettings");
+            Navigation.PopModalAsync();
         }
     }
 }

--- a/HodlWallet/UI/Views/LoginView.xaml.cs
+++ b/HodlWallet/UI/Views/LoginView.xaml.cs
@@ -164,11 +164,11 @@ namespace HodlWallet.UI.Views
             Application.Current.MainPage = new AppShell();
         }
 
-        void UpdatePin(LoginViewModel _)
+        async void UpdatePin(LoginViewModel _)
         {
             Debug.WriteLine($"[SubscribeToMessage][UpdatePin]");
 
-            Navigation.PushAsync(new PinPadView(new PinPadChangeView()));
+            await Navigation.PushAsync(new PinPadView("PinPadChangeView"));
             UnsubscribeToMessages();
             return;
         }
@@ -209,13 +209,20 @@ namespace HodlWallet.UI.Views
         {
             UnsubscribeToMessages();
             var view = new BiometricLoginView(ViewModel.Action);
-            var nav = new NavigationPage(view);
-            await Navigation.PushModalAsync(nav);
+            if (ViewModel.Action == "update")
+            {
+                await Navigation.PushAsync(view);
+            }
+            else
+            {
+                var nav = new NavigationPage(view);
+                await Navigation.PushModalAsync(nav);
+            }
         }
 
-        async void CloseToolbarItem_Clicked(object sender, EventArgs e)
+        void CloseToolbarItem_Clicked(object sender, EventArgs e)
         {
-            await Shell.Current.GoToAsync("../../pinSettings");
+            Navigation.PopModalAsync();
         }
     }
 }

--- a/HodlWallet/UI/Views/OnboardView.xaml.cs
+++ b/HodlWallet/UI/Views/OnboardView.xaml.cs
@@ -44,7 +44,7 @@ namespace HodlWallet.UI.Views
                 await Navigation.PushAsync(view);
             else
             {
-                await Navigation.PushAsync(new PinPadView(view));
+                await Navigation.PushAsync(new PinPadView("NewWalletInfoView"));
             }
         }
 
@@ -56,7 +56,7 @@ namespace HodlWallet.UI.Views
                 await Navigation.PushAsync(view);
             else
             {
-                await Navigation.PushAsync(new PinPadView(view));
+                await Navigation.PushAsync(new PinPadView("RecoverInfoView"));
             }
         }
 

--- a/HodlWallet/UI/Views/PinPadView.xaml
+++ b/HodlWallet/UI/Views/PinPadView.xaml
@@ -10,6 +10,13 @@
     <ContentPage.BindingContext>
         <vm:PinPadViewModel />
     </ContentPage.BindingContext>
+    <ContentPage.ToolbarItems>
+        <ToolbarItem x:Name="CloseToolbarItem"
+                     Order="Primary"
+                     Text="{i18n:Translate Text=PinPad.close}"
+                     Priority="0"
+                     Clicked="CloseToolbarItem_Clicked" />
+    </ContentPage.ToolbarItems>
     <ContentPage.Content>
         <FlexLayout>
             <controls:PinPad x:Name="PinPadControl" Command="{Binding SuccessCommand}" />

--- a/HodlWallet/UI/Views/PinPadView.xaml.cs
+++ b/HodlWallet/UI/Views/PinPadView.xaml.cs
@@ -33,15 +33,16 @@ namespace HodlWallet.UI.Views
 {
     public partial class PinPadView : ContentPage
     {
-        string nextView;
+        PinPadViewModel ViewModel => (PinPadViewModel)BindingContext;
+        
         public PinPadView(string nextView)
         {
             InitializeComponent();
             SetPinPadControlBindings();
             SubscribeToMessages();
 
-            this.nextView = nextView;
-            if (this.nextView == "PinPadChangeView")
+            ViewModel.NextView = nextView;
+            if (ViewModel.NextView == "PinPadChangeView")
             {
                 CloseToolbarItem.IsEnabled = true;
             }
@@ -74,7 +75,7 @@ namespace HodlWallet.UI.Views
 
         async void NavigateToNextView(PinPadViewModel _)
         {
-            switch(nextView)
+            switch(ViewModel.NextView)
             {
                 case "NewWalletInfoView":
                     await Navigation.PushAsync(new NewWalletInfoView());

--- a/HodlWallet/UI/Views/PinPadView.xaml.cs
+++ b/HodlWallet/UI/Views/PinPadView.xaml.cs
@@ -33,16 +33,27 @@ namespace HodlWallet.UI.Views
 {
     public partial class PinPadView : ContentPage
     {
-        readonly ContentPage nextView;
-
-        public PinPadView(ContentPage nextView)
+        string nextView;
+        public PinPadView(string nextView)
         {
-            this.nextView = nextView;
-
             InitializeComponent();
-
             SetPinPadControlBindings();
             SubscribeToMessages();
+
+            this.nextView = nextView;
+            if (this.nextView == "PinPadChangeView")
+            {
+                CloseToolbarItem.IsEnabled = true;
+            }
+            else
+            {
+                CloseToolbarItem.IsEnabled = false;
+            }
+        }
+
+        void CloseToolbarItem_Clicked(object sender, EventArgs e)
+        {
+            Navigation.PopModalAsync();
         }
 
         void SetPinPadControlBindings()
@@ -63,7 +74,20 @@ namespace HodlWallet.UI.Views
 
         async void NavigateToNextView(PinPadViewModel _)
         {
-            await Navigation.PushAsync(nextView);
+            switch(nextView)
+            {
+                case "NewWalletInfoView":
+                    await Navigation.PushAsync(new NewWalletInfoView());
+                    break;
+
+                case "PinPadChangeView":
+                    await Navigation.PushAsync(new PinPadChangeView());
+                    break;
+
+                case "RecoverInfoView":
+                    await Navigation.PushAsync(new RecoverInfoView());
+                    break;
+            }
 
             // No page should go back to the pinpad view
             if (Navigation.NavigationStack.Contains(this)) Navigation.RemovePage(this);

--- a/HodlWallet/UI/Views/PinSettingsView.xaml.cs
+++ b/HodlWallet/UI/Views/PinSettingsView.xaml.cs
@@ -46,7 +46,7 @@ namespace HodlWallet.UI.Views
             Navigation.PopModalAsync();
         }
 
-        void UpdatePin_Clicked(object sender, EventArgs e)
+        async void UpdatePin_Clicked(object sender, EventArgs e)
         {
             string lastLogin = Preferences.Get("lastLogin", "pin");
             bool biometricsAllow = Preferences.Get("biometricsAllow", false);
@@ -55,12 +55,12 @@ namespace HodlWallet.UI.Views
             if (biometricsAllow & (lastLogin == "biometric" & availability))
             {
                 var view = new BiometricLoginView("update");
-                Navigation.PushAsync(view);
+                await Navigation.PushAsync(view);
             }
             else
             {
                 var view = new LoginView("update");
-                Navigation.PushAsync(view);
+                await Navigation.PushAsync(view);
             }
         }
 

--- a/HodlWallet/UI/Views/SecuritySettingsView.xaml
+++ b/HodlWallet/UI/Views/SecuritySettingsView.xaml
@@ -7,6 +7,14 @@
              Title="{i18n:Translate Security.title}"
              NavigationPage.HasNavigationBar="True"
              BackgroundColor="{DynamicResource Bg}">
+
+    <ContentPage.ToolbarItems>
+        <ToolbarItem x:Name="CloseToolbarItem"
+                     Order="Primary"
+                     Text="{i18n:Translate Text=Security.close}"
+                     Priority="0"
+                     Clicked="CloseToolbarItem_Clicked" />
+    </ContentPage.ToolbarItems>
     <ContentPage.Content>
         <FlexLayout>
             <ScrollView x:Name="MenuScroll">

--- a/HodlWallet/UI/Views/SecuritySettingsView.xaml.cs
+++ b/HodlWallet/UI/Views/SecuritySettingsView.xaml.cs
@@ -34,7 +34,12 @@ namespace HodlWallet.UI.Views
         {
             InitializeComponent();
         }
-        
+
+        void CloseToolbarItem_Clicked(object sender, EventArgs e)
+        {
+            Navigation.PopModalAsync();
+        }
+
         async void BackupMnemonic_Clicked(object sender, EventArgs e)
         {
             var view = new BackupView(action: "close");
@@ -45,10 +50,7 @@ namespace HodlWallet.UI.Views
 
         async void PinButton_Clicked(object sender, EventArgs e)
         {
-            var view = new PinSettingsView();
-            var nav = new NavigationPage(view);
-
-            await Navigation.PushModalAsync(nav);
+            await Navigation.PushAsync(new PinSettingsView());
         }
 
         async void Biometrics_Clicked(object sender, EventArgs e)

--- a/HodlWallet/UI/Views/SettingsView.xaml.cs
+++ b/HodlWallet/UI/Views/SettingsView.xaml.cs
@@ -129,7 +129,10 @@ namespace HodlWallet.UI.Views
 
         async void Security_Clicked(object sender, EventArgs e)
         {
-            await Navigation.PushAsync(new SecuritySettingsView());
+            var view = new SecuritySettingsView();
+            var nav = new NavigationPage(view);
+
+            await Navigation.PushModalAsync(nav);
         }
 
         async void AccountSettings_Clicked(object sender, EventArgs e)


### PR DESCRIPTION
### Summary
The changes of this branch are oriented to fix the changing of color of the settings page after updating the pin, this was happening due to lacks on the navigation.

The structure used in the navigation in settings had the previous shape because it needed to work with the authentication, so it was necessary to modify the navigation in the LoginView and BiometricLoginView, using PushAsync when updating the pin and PushModalAsync when the authentication pops after inactivity.

There is a proposal in this branch, it is to have a back button and a close button in every view of the menu, the back view should return to the previous view (there are some exceptions…) and the close button should cancel everything and return to the settings view. These could be more comfortable for the user.

For this, there are changes on the navigation of the views after Settings/Security/Pin, this is to show the behavior of this proposal, waiting for the instructions for uniforming the navigation of the other views of the menu.

There is also a change in the way of calling the next view in the PinPadView, previously the next view was provided as a ContentPage parameter, now the parameter is a string with the name of the next view, so it was necessary to add the NextView property in the PinPadViewModel. This difference in the next view allows to differentiate when the close button is enabled and when it is not.


### Other Information

There are some close buttons added at some views and the translation of this closes were added to the LocaleResources for translations.
