### PR TITLE
77 amount zero

### DIFF
--- a/HodlWallet/Core/ViewModels/HomeViewModel.cs
+++ b/HodlWallet/Core/ViewModels/HomeViewModel.cs
@@ -403,6 +403,7 @@ namespace HodlWallet.Core.ViewModels
             {
                 lock (@lock)
                 {
+                    Balance = WalletService.GetCurrentAccountBalanceInBTC(includeUnconfirmed: true);
                     LoadTransactions();
 
                     AddWalletServiceEvents();

--- a/HodlWallet/Core/ViewModels/HomeViewModel.cs
+++ b/HodlWallet/Core/ViewModels/HomeViewModel.cs
@@ -404,6 +404,7 @@ namespace HodlWallet.Core.ViewModels
                 lock (@lock)
                 {
                     Balance = WalletService.GetCurrentAccountBalanceInBTC(includeUnconfirmed: true);
+                    MessagingCenter.Send(this, "BalanceLabelToVisible");
                     LoadTransactions();
 
                     AddWalletServiceEvents();

--- a/HodlWallet/UI/Views/HomeView.xaml.cs
+++ b/HodlWallet/UI/Views/HomeView.xaml.cs
@@ -30,6 +30,7 @@ using HodlWallet.Core.Interfaces;
 using HodlWallet.Core.Models;
 using HodlWallet.Core.ViewModels;
 using HodlWallet.UI.Extensions;
+
 using Liviano.Interfaces;
 
 namespace HodlWallet.UI.Views
@@ -42,10 +43,10 @@ namespace HodlWallet.UI.Views
         public HomeView()
         {
             InitializeComponent();
+            SubscribeToMessages();
+
             BalanceLabel.IsVisible = false;
 
-            SubscribeToMessages();
-            
             if (WalletService.Syncing)
             {
                 SyncToolbarItem.IsVisible = true;
@@ -87,7 +88,7 @@ namespace HodlWallet.UI.Views
 
         void BalanceLabelToVisible(HomeViewModel _)
         {
-            BalanceLabel.IsVisible=true;
+            BalanceLabel.IsVisible = true;
         }
 
         async void NavigateToTransactionDetail(HomeViewModel _, TransactionModel txModel)

--- a/HodlWallet/UI/Views/HomeView.xaml.cs
+++ b/HodlWallet/UI/Views/HomeView.xaml.cs
@@ -42,9 +42,10 @@ namespace HodlWallet.UI.Views
         public HomeView()
         {
             InitializeComponent();
+            BalanceLabel.IsVisible = false;
 
             SubscribeToMessages();
-
+            
             if (WalletService.Syncing)
             {
                 SyncToolbarItem.IsVisible = true;
@@ -81,6 +82,12 @@ namespace HodlWallet.UI.Views
         {
             MessagingCenter.Subscribe<HomeViewModel, TransactionModel>(this, "NavigateToTransactionDetail", NavigateToTransactionDetail);
             MessagingCenter.Subscribe<HomeViewModel>(this, "SwitchCurrency", SwitchCurrency);
+            MessagingCenter.Subscribe<HomeViewModel>(this, "BalanceLabelToVisible", BalanceLabelToVisible);
+        }
+
+        void BalanceLabelToVisible(HomeViewModel _)
+        {
+            BalanceLabel.IsVisible=true;
         }
 
         async void NavigateToTransactionDetail(HomeViewModel _, TransactionModel txModel)


### PR DESCRIPTION
### Summary

These changes are oriented to make the app more friendly with the user. Previously, when the app loaded the HomeView, it used to show the amount balance equal to zero, and it make the loading of the correct amount only after executing the OnAppearing method, this happens for example after changing to another tab and returning to HomeView.

So, it was necessary to add the instruction to assign the amount to the Balance property without the necessity to use the OnAppearing method, this was made with the addition of the assignation of the balance in the WalletService_OnStarted method at the HomeViewModel.

After that, the balance is equal to zero when the view is showed and only changes to the correct amount after some moments, when the service is loaded, therefore it is better to hide the zero value until the right balance is loaded.

This was made changing the visibility of the Balance to false when HomeView is loaded and returning it to true value after loading the right balance, this is made through the BalanceLabelToVisible method.
