### PR TITLE
98 create multiple accounts

### DIFF
--- a/HodlWallet/Core/Utils/Constants.cs
+++ b/HodlWallet/Core/Utils/Constants.cs
@@ -110,8 +110,13 @@ namespace HodlWallet.Core.Utils
         public const string DISPLAY_ALERT_SCAN_MESSAGE = "Invalid QR code."; 
         public const string DISPLAY_ALERT_ERROR_SEND_TO_YOURSELF = "Send to yourself is disabled."; 
         public const string DISPLAY_ALERT_ERROR_BIP70 = "BIP70 is not supported."; 
-        public const string DISPLAY_ALERT_TRANSACTION_MESSAGE = "There was an error broadcasting your transaction."; 
-        public const string DISPLAY_ALERT_AMOUNT_MESSAGE = "Unable to send, check your amount, address and fee"; 
+        public const string DISPLAY_ALERT_TRANSACTION_MESSAGE = "There was an error broadcasting your transaction.";
+        public const string DISPLAY_ALERT_AMOUNT_MESSAGE = "Unable to send, check your amount, address and fee";
+        public const string DISPLAY_ALERT_CREATING_ACCOUNT_PROGRESS_MESSAGE = "Account creation in progress...";
+        public const string DISPLAY_ALERT_SUCCESS_ACCOUNT_CREATION_MESSAGE = "Account successfuly created";
+        public const string LABEL_ALERT_CREATING_ACCOUNT_PROGRESS_MESSAGE = "DisplayCreatingAccountNotification";
+        public const string LABEL_ALERT_SUCCESS_ACCOUNT_CREATION_MESSAGE = "DisplaySuccessAccountCreationNotification";
+        public const string LABEL_ERROR_ACCOUNT_CREATION_MESSAGE = "DisplayErrorCreatingAccount";
 
         // Temporary Values
         public const string USE_ADDRESS_FROM_CLIPBOARD = "The Bitcoin address '{0} is in your clipboard, would you like to send to that address?";

--- a/HodlWallet/Core/ViewModels/CreateAccountViewModel.cs
+++ b/HodlWallet/Core/ViewModels/CreateAccountViewModel.cs
@@ -27,6 +27,7 @@ using System.Windows.Input;
 
 using Xamarin.Forms;
 
+using HodlWallet.Core.Utils;
 using HodlWallet.UI.Controls;
 using HodlWallet.UI.Converters;
 using HodlWallet.UI.Locale;
@@ -78,22 +79,32 @@ namespace HodlWallet.Core.ViewModels
             AccountColor = $"{colorCode}{color.ToHexString()}";
 
             string keyType = GetKeyFromValue();
-
+            DisplayCreatingAccountAlert(
+                Constants.LABEL_ALERT_CREATING_ACCOUNT_PROGRESS_MESSAGE);
             (bool Success, string Error) = await WalletService.AddAccount(keyType, AccountName, AccountColor);
 
             if (!Success && !string.IsNullOrEmpty(Error))
             {
-                DisplayProcessAccountErrorAlert(Error);
+                DisplayCreatingAccountAlert(
+                    Constants.LABEL_ERROR_ACCOUNT_CREATION_MESSAGE, Error);
             }
             else
             {
+                DisplayCreatingAccountAlert(
+                    Constants.LABEL_ALERT_SUCCESS_ACCOUNT_CREATION_MESSAGE);
                 await Shell.Current.GoToAsync("..");
             }
         }
 
-        void DisplayProcessAccountErrorAlert(string errorMessage)
+        void DisplayCreatingAccountAlert(string labelMessage, string errorMessage = "")
         {
-            MessagingCenter.Send(this, "DisplayErrorCreatingAccount", errorMessage);
+            var message = Constants.DISPLAY_ALERT_CREATING_ACCOUNT_PROGRESS_MESSAGE;
+            if (!string.IsNullOrEmpty(errorMessage))
+                message = errorMessage;
+            else if (labelMessage.Equals(Constants.LABEL_ALERT_SUCCESS_ACCOUNT_CREATION_MESSAGE))
+                message = Constants.DISPLAY_ALERT_SUCCESS_ACCOUNT_CREATION_MESSAGE; ;
+
+            MessagingCenter.Send(this, labelMessage, message);
         }
 
         string GetKeyFromValue()

--- a/HodlWallet/UI/Views/CreateAccountView.xaml
+++ b/HodlWallet/UI/Views/CreateAccountView.xaml
@@ -65,7 +65,8 @@
             <controls:ColorPicker x:Name="PickColorControl" ButtonColorSelected="{Binding AccountColor}" />
 
             <BoxView x:Name="boxView" FlexLayout.Grow="1"/>
-            <Button Text="{i18n:Translate Text=AddAccount.createButton}"
+            <Button x:Name="AddAcountButton"
+                    Text="{i18n:Translate Text=AddAccount.createButton}"
                     Command="{Binding CreateAccountCommand}"
                     CommandParameter="{Binding Source={x:Reference PickColorControl}, Path=ColorCode}"
                     Style="{DynamicResource CustomButton}"

--- a/HodlWallet/UI/Views/CreateAccountView.xaml.cs
+++ b/HodlWallet/UI/Views/CreateAccountView.xaml.cs
@@ -64,6 +64,13 @@ namespace HodlWallet.UI.Views
         void DisplayNotification(CreateAccountViewModel vm, string message)
         {
             _ = this.DisplayToast(message);
+            // When in progress disable to avoid more than one account creations.
+            if (message == Constants.DISPLAY_ALERT_CREATING_ACCOUNT_PROGRESS_MESSAGE)
+                AddAcountButton.IsEnabled = false;
+
+            // After an error message validation is shown in the view, the button should be enabled again.
+            if (!string.Equals(message, Constants.DISPLAY_ALERT_CREATING_ACCOUNT_PROGRESS_MESSAGE))
+                AddAcountButton.IsEnabled = true;
         }
 
         void SetSuggestedColor()

--- a/HodlWallet/UI/Views/CreateAccountView.xaml.cs
+++ b/HodlWallet/UI/Views/CreateAccountView.xaml.cs
@@ -25,8 +25,8 @@ using System;
 using Xamarin.Forms;
 
 using HodlWallet.Core.ViewModels;
+using HodlWallet.Core.Utils;
 using HodlWallet.UI.Extensions;
-using System.Diagnostics;
 
 namespace HodlWallet.UI.Views
 {
@@ -56,12 +56,14 @@ namespace HodlWallet.UI.Views
 
         void SubscribeToMessages()
         {
-            MessagingCenter.Subscribe<CreateAccountViewModel, string>(this, "DisplayErrorCreatingAccount", DisplayErrorCreatingAccount);
+            MessagingCenter.Subscribe<CreateAccountViewModel, string>(this, Constants.LABEL_ERROR_ACCOUNT_CREATION_MESSAGE, DisplayNotification);
+            MessagingCenter.Subscribe<CreateAccountViewModel, string>(this, Constants.LABEL_ALERT_CREATING_ACCOUNT_PROGRESS_MESSAGE, DisplayNotification);
+            MessagingCenter.Subscribe<CreateAccountViewModel, string>(this, Constants.LABEL_ALERT_SUCCESS_ACCOUNT_CREATION_MESSAGE, DisplayNotification);
         }
 
-        void DisplayErrorCreatingAccount(CreateAccountViewModel vm, string errorMessage)
+        void DisplayNotification(CreateAccountViewModel vm, string message)
         {
-            _ = this.DisplayToast(errorMessage);
+            _ = this.DisplayToast(message);
         }
 
         void SetSuggestedColor()


### PR DESCRIPTION

### Summary

Added popup notifications to alert about the account creation progress. 
When the Create button is pressed, the view is closed. If the account was created without errors, a popup notification is shown. Also, If an error occurs trying to create the account, the error message got from the Wallet Service is shown.
