### PR TITLE
Modified style to show transaction details and link to blockexplorer

### DIFF
--- a/HodlWallet/Core/ViewModels/TransactionDetailsViewModel.cs
+++ b/HodlWallet/Core/ViewModels/TransactionDetailsViewModel.cs
@@ -34,6 +34,7 @@ using Liviano.Models;
 using HodlWallet.Core.Models;
 using HodlWallet.Core.Utils;
 using HodlWallet.UI.Locale;
+using System.Diagnostics;
 
 namespace HodlWallet.Core.ViewModels
 {
@@ -223,14 +224,28 @@ namespace HodlWallet.Core.ViewModels
         {
             var uri = new Uri(string.Format(BlockExplorerAddressUri, Address));
 
-            await Browser.OpenAsync(uri, BrowserLaunchMode.External);
+            try
+            {
+                await Browser.OpenAsync(uri, BrowserLaunchMode.SystemPreferred);
+            }
+            catch (Exception e)
+            {
+                Debug.WriteLine("Could not open Browser --> " + e); 
+            }
         }
 
         async Task IdToBrowser()
         {
             var uri = new Uri(string.Format(BlockExplorerTransactionsUri, Id));
 
-            await Browser.OpenAsync(uri, BrowserLaunchMode.External);
+            try
+            {
+                await Browser.OpenAsync(uri, BrowserLaunchMode.SystemPreferred);
+            }
+            catch (Exception e)
+            {
+                Debug.WriteLine("Could not open Browser --> " + e);
+            }
         }
     }
 }

--- a/HodlWallet/UI/App.xaml
+++ b/HodlWallet/UI/App.xaml
@@ -195,8 +195,6 @@
                    TargetType="Button">
                 <Setter Property="BackgroundColor"
                         Value="{DynamicResource Bg}" />
-                <Setter Property="HeightRequest"
-                        Value="20" />
                 <Setter Property="FontFamily"
                         Value="{StaticResource Sans-Regular}" />
                 <Setter Property="FontSize"

--- a/HodlWallet/UI/Views/TransactionDetailsView.xaml
+++ b/HodlWallet/UI/Views/TransactionDetailsView.xaml
@@ -85,7 +85,7 @@
                                ReturnType="Done"/>
 
                         <BoxView Style="{StaticResource TransactionDetailsBoxView}" />
-
+                        <!-- Amount -->
                         <Label Style="{StaticResource TransactionDetailTitle}"
                                Text="{Binding AmountTitle, Converter={StaticResource UpperCaseConverter}}" />
                         <Label FontSize="Small"
@@ -101,6 +101,7 @@
 
                         <BoxView Style="{StaticResource TransactionDetailsBoxView}" />
 
+                        <!-- To this Address -->
                         <Label Style="{StaticResource TransactionDetailTitle}"
                                Text="{Binding AddressTitle, Converter={StaticResource UpperCaseConverter}}" />
                         <Button Command="{Binding BrowseAddressCommand}"
@@ -109,6 +110,7 @@
 
                         <BoxView Style="{StaticResource TransactionDetailsBoxView}" />
 
+                        <!-- TxID  -->
                         <Label Style="{StaticResource TransactionDetailTitle}"
                                Text="{Binding TransactionIdTitle, Converter={StaticResource UpperCaseConverter}}" />
                         <Button Command="{Binding BrowseTransactionIdCommand}"

--- a/HodlWallet/UI/Views/TransactionDetailsView.xaml
+++ b/HodlWallet/UI/Views/TransactionDetailsView.xaml
@@ -57,7 +57,7 @@
                                Text="{Binding AddressText}" />
                         <Label FontSize="Medium"
                                Style="{StaticResource TransactionDetailLabel}"
-                               Text="{Binding CreationTimeText}" />
+                               Text="{Binding CreatedAtText}" />
                         <Label FontSize="Medium"
                                Style="{StaticResource TransactionDetailLabel}"
                                Text="{Binding AmountText}"


### PR DESCRIPTION
Signed-off-by: marconipoveda <marconipoveda84@gmail.com>

### Summary
Fixed transaction details view.

- Updated TransactionDetailsButton style to use automatic height. `HeightRequest=20` wasn't enough to show the full address and Tx Id.
- Added exceptions management for browser launch.
- Switched `BrowserLaunchMode` from `External` to `SystemPrefered`.  `External` triggers a `Feature not supported` exception.